### PR TITLE
fix: check if addEventListener and RemoveEventListener methods exist

### DIFF
--- a/src/Draggable.js
+++ b/src/Draggable.js
@@ -1,10 +1,10 @@
 const proxy = (a, b) => (e) => b(a(e));
 
 const bind = (el, event, callback) =>
-    el.addEventListener(event, callback);
+    el.addEventListener && el.addEventListener(event, callback);
 
 const unbind = (el, event, callback) =>
-    el.removeEventListener(event, callback);
+    el.removeEventListener && el.removeEventListener(event, callback);
 
 const touchRegExp = /touch/;
 


### PR DESCRIPTION
Check if addEventListener and RemoveEventListener methods exist for the element before calling them.