### PR TITLE
fix: release the capture on up event

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -117,6 +117,7 @@ export class Draggable {
             if (e.isPrimary) {
                 unbind(this._element, "pointermove", this._pointermove);
                 e.target.style.touchAction = this._touchAction;
+                e.target.releasePointerCapture(e.pointerId);
                 this._releaseHandler(e);
             }
         };


### PR DESCRIPTION
Manually release the capture on up event due to bug or odd behavior in IE.