### PR TITLE
feat: add mouseOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,8 @@ The Kendo UI Draggable supports:
 
 - Mouse events
 - Touch events
+- Pointer events
 - Handling of multiple touches. Rather, not getting confused by them.
-
-## What's Next
-
-Support for Pointer events support, necessary for the Windows Phone platform.
 
 ## Dragging on iOS/Android
 
@@ -91,6 +88,30 @@ Handling the drag sequence on mobile devices may require the disabling of the to
 ## Preventing Selection
 
 The dragging of elements that contain text activates the browser text selection, which, in most cases, is not desirable. To avoid this behavior, use the [`user-select: none`](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select) CSS property with its respective browser prefixes.
+
+## Mouse-Only mode
+
+To ignore all touch and pointer events, set `mouseOnly` to `true`. This is useful when you want to keep the default touch-drag behavior, e.g. horizontal scroll.
+
+```javascript
+import Draggable from '@telerik/kendo-draggable';
+
+const draggable = new Draggable({
+    mouseOnly: true,
+    press: function(e) {
+        console.log("pressed", e.pageX, e.pageY);
+    },
+    drag: function(e) {
+        console.log("drag", e.pageX, e.pageY);
+    },
+    release: function(e) {
+        console.log("release", e.pageX, e.pageY);
+    }
+});
+
+draggable.bindTo(document.getElementById("my-element"));
+```
+
 
 ## Browser Support
 

--- a/e2e/draggable-compat.js
+++ b/e2e/draggable-compat.js
@@ -235,4 +235,29 @@ describe('Draggable with Mouse and Touch events fallback', () => {
             clock.uninstall();
         });
     });
+
+    describe("with mouseOnly set to true", () => {
+        beforeEach(() => {
+            handler = jasmine.createSpy("onPress");
+
+            draggable = new Draggable({
+                press: handler,
+                mouseOnly: true
+            });
+
+            draggable.bindTo(el);
+        });
+
+        it("emits press on mousedown", () => {
+            mousedown(el, 100, 200);
+
+            expect(handler).toHaveBeenCalled();
+        });
+
+        it("does not emit press on touchstart", () => {
+            touchstart(el, 100, 200);
+
+            expect(handler).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/e2e/draggable.js
+++ b/e2e/draggable.js
@@ -147,5 +147,24 @@ describe('Draggable with Pointer events', () => {
             expect(el.style.touchAction).toEqual('pan-y');
         });
     });
+
+    describe("with mouseOnly set to true", () => {
+        beforeEach(() => {
+            handler = jasmine.createSpy("onPress");
+
+            draggable = new Draggable({
+                press: handler,
+                mouseOnly: true
+            });
+
+            draggable.bindTo(el);
+        });
+
+        it("does not emit press on pointerdown", () => {
+            pointerdown(el, 100, 200);
+
+            expect(handler).not.toHaveBeenCalled();
+        });
+    });
 });
 

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -1,7 +1,8 @@
 interface DraggableOptions {
     press?: Function,
     drag?: Function,
-    release?: Function
+    release?: Function,
+    mouseOnly?: boolean
 }
 
 export default class Draggable {


### PR DESCRIPTION
Useful for horizontal scroll where the built-in touch behavior is fine, but mouse scrolling does not work.