### PR TITLE
feat: pass normalized clientX and clientY values

### DIFF
--- a/e2e/draggable-compat.js
+++ b/e2e/draggable-compat.js
@@ -111,6 +111,12 @@ describe('Draggable with Mouse and Touch events fallback', () => {
 
             expect(handler).toHaveBeenCalledTimes(1);
         });
+
+        it('normalizes clientX and clientY', () => {
+            const args = handler.calls.argsFor(0)[0];
+            expect(args.clientX).toBe(101);
+            expect(args.clientY).toBe(201);
+        });
     });
 
     describe("Touch drag", () => {
@@ -143,6 +149,12 @@ describe('Draggable with Mouse and Touch events fallback', () => {
         it("ignores gestures", () => {
             gesturemove(el, 101, 201, 102, 202);
             expect(handler).toHaveBeenCalledTimes(1);
+        });
+
+        it('normalizes clientX and clientY', () => {
+            const args = handler.calls.argsFor(0)[0];
+            expect(args.clientX).toBe(101);
+            expect(args.clientY).toBe(201);
         });
     });
 

--- a/e2e/draggable.js
+++ b/e2e/draggable.js
@@ -110,6 +110,14 @@ describe('Draggable with Pointer events', () => {
             pointermove(el, 101, 201);
             expect(handler).not.toHaveBeenCalled();
         });
+
+        it('normalizes clientX and clientY', () => {
+            drag();
+
+            const args = handler.calls.argsFor(0)[0];
+            expect(args.clientX).toBe(101);
+            expect(args.clientY).toBe(201);
+        });
     });
 
     describe("Release", () => {

--- a/e2e/util.js
+++ b/e2e/util.js
@@ -15,7 +15,9 @@ const aTouch = (el, x, y, id) =>
         identifier: id,
         target: el,
         pageX: x,
-        pageY: y
+        pageY: y,
+        clientX: x,
+        clientY: y
     });
 
 const aTouchEvent = (type, touches) =>

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,8 @@ function normalizeEvent(e) {
         return {
             pageX: e.changedTouches[0].pageX,
             pageY: e.changedTouches[0].pageY,
+            clientX: e.changedTouches[0].pageX,
+            clientY: e.changedTouches[0].clientY,
             type: e.type,
             originalEvent: e
         };
@@ -27,6 +29,8 @@ function normalizeEvent(e) {
     return {
         pageX: e.pageX,
         pageY: e.pageY,
+        clientX: e.clientX,
+        clientY: e.clientY,
         offsetX: e.offsetX,
         offsetY: e.offsetY,
         type: e.type,

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ function normalizeEvent(e) {
         return {
             pageX: e.changedTouches[0].pageX,
             pageY: e.changedTouches[0].pageY,
-            clientX: e.changedTouches[0].pageX,
+            clientX: e.changedTouches[0].clientX,
             clientY: e.changedTouches[0].clientY,
             type: e.type,
             originalEvent: e


### PR DESCRIPTION
Needed since clientX and clientY are not directly available for the TouchEvents. As result [this](https://github.com/telerik/kendo-angular-grid/blob/develop/src/dragdrop/draggable-column.directive.ts#L61) code fails on touch devices.