### PR TITLE
check if element exists before removing eventListener from it

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ const bind = (el, event, callback) =>
     el.addEventListener && el.addEventListener(event, callback);
 
 const unbind = (el, event, callback) =>
-    el.removeEventListener && el.removeEventListener(event, callback);
+    el && el.removeEventListener && el.removeEventListener(event, callback);
 
 const noop = () => { /* empty */ };
 


### PR DESCRIPTION
@danielkaradachki 
In the `unbind` function, there should be a check for whether `el` exists before calling `el.removeEventListener`. This can be done by simply adding `el &&` before it.