### PR TITLE
fix: remove touch-action handling

### DIFF
--- a/e2e/draggable.js
+++ b/e2e/draggable.js
@@ -73,11 +73,6 @@ describe('Draggable with Pointer events', () => {
 
             expect(handler).toHaveBeenCalledTimes(1);
         });
-
-        it("sets touch-action to none on pointerdown", () => {
-            pointerdown(el, 100, 200);
-            expect(el.style.touchAction).toEqual('none');
-        });
     });
 
     describe("Drag", () => {
@@ -224,19 +219,6 @@ describe('Draggable with Pointer events', () => {
 
             expect(contextmenu.preventDefault).not.toHaveBeenCalled();
             expect(handler).not.toHaveBeenCalled();
-        });
-
-        it("restores auto touch-action on pointerup", () => {
-            pointerdown(el, 100, 200);
-            pointerup(el, 100, 200);
-            expect(el.style.touchAction).toEqual('');
-        });
-
-        it("restores previous touch-action on pointerup", () => {
-            el.style.touchAction = 'pan-y';
-            pointerdown(el, 100, 200);
-            pointerup(el, 100, 200);
-            expect(el.style.touchAction).toEqual('pan-y');
         });
 
     });

--- a/src/main.js
+++ b/src/main.js
@@ -55,7 +55,6 @@ export class Draggable {
         this._releaseHandler = proxy(normalizeEvent, release);
         this._ignoreMouse = false;
         this._mouseOnly = mouseOnly;
-        this._touchAction;
 
         this._touchstart = (e) => {
             if (e.touches.length === 1) {
@@ -112,9 +111,6 @@ export class Draggable {
                 bind(document, "pointercancel", this._pointerup);
                 bind(document, "contextmenu", preventDefault);
 
-                this._touchAction = e.target.style.touchAction;
-                e.target.style.touchAction = "none";
-
                 this._pressHandler(e);
             }
         };
@@ -131,8 +127,6 @@ export class Draggable {
                 unbind(document, "pointerup", this._pointerup);
                 unbind(document, "pointercancel", this._pointerup);
                 unbind(document, "contextmenu", preventDefault);
-
-                e.target.style.touchAction = this._touchAction;
 
                 this._releaseHandler(e);
             }


### PR DESCRIPTION
Doesn't work without setPointerCapture as the target changes. Also, causes error in certain cases:
https://github.com/telerik/kendo-draggable/issues/27
It's not the draggables job to handle the touch-action anyway. The user may allow the browser touch action on specific axis or to prevent the touch-action just for specific children or based on certain conditions. 

Not sure if this should be considered as breaking change? 