### PR TITLE
feat: expose update function

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
+    "@types/node": "^10.17.13",
     "@progress/kendo-package-tasks": "^3.0.19",
     "@telerik/eslint-config": "^1.0.0",
     "@telerik/semantic-prerelease": "^1.3.3",

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -7,6 +7,7 @@ interface DraggableOptions {
 
 export default class Draggable {
     constructor(options?: DraggableOptions);
+    update(options?: DraggableOptions): void;
     bindTo(element: Element): void;
     destroy(): void;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -188,6 +188,13 @@ export class Draggable {
         return !this._mouseOnly && Draggable.supportPointerEvent();
     }
 
+    update({ press = noop, drag = noop, release = noop, mouseOnly = false }) {
+        this._pressHandler = proxy(normalizeEvent, press);
+        this._dragHandler = proxy(normalizeEvent, drag);
+        this._releaseHandler = proxy(normalizeEvent, release);
+        this._mouseOnly = mouseOnly;
+    }
+
     destroy() {
         this._unbindFromCurrent();
         this._element = null;


### PR DESCRIPTION
This feature should allow draggable handlers to be updated during dragging.

The problem which we're solving is with how callbacks are handled in React functional components, where a callback can be conditionally updated based on a property.

We are failing in the following scenario:

```jsx
const handleDrop = React.useCallback(
  () => {
    // ...use the "drag" variable
  },
  // the callback will be re-initiated whenever the "drag" property changes, but the draggable instance have the old callback
  [drag]
)
```

Please let me know if you have any concerns.