### PR TITLE
chore: update publishing token name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Publish release
         run: npx ci-semantic-release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_TELERIK }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
The package is in `@telerik` hence the different token.