### PR TITLE
 fix: change package scope to @progress 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "rules": {
+    }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "./node_modules/@telerik/eslint-config/react.js"
-}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Publish release
         run: npx ci-semantic-release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN_TELERIK }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: '14'
 
       - name: Install modules
-        run: npm install @telerik/semantic-prerelease@1 --no-save
+        run: npm install @progress/semantic-prerelease --no-save
 
       - name: Fast-forward master to develop
         run: npx release-master

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A drag sequence means:
 The library is published as a [scoped NPM package](https://docs.npmjs.com/misc/scope) in the [NPMJS Telerik account](https://www.npmjs.com/~telerik).
 
 ```bash
-npm install --save '@telerik/kendo-draggable';
+npm install --save '@progress/kendo-draggable';
 ```
 
 ## Basic Usage
@@ -35,7 +35,7 @@ npm install --save '@telerik/kendo-draggable';
 The `draggable` class constructor accepts an object with three optional event handler callbacks&mdash;`press`, `drag`, and `release`.
 
 ```javascript
-import Draggable from '@telerik/kendo-draggable';
+import Draggable from '@progress/kendo-draggable';
 
 const draggable = new Draggable({
     press: function(e) {
@@ -94,7 +94,7 @@ The dragging of elements that contain text activates the browser text selection,
 To ignore all touch and pointer events, set `mouseOnly` to `true`. This is useful when you want to keep the default touch-drag behavior, e.g. horizontal scroll.
 
 ```javascript
-import Draggable from '@telerik/kendo-draggable';
+import Draggable from '@progress/kendo-draggable';
 
 const draggable = new Draggable({
     mouseOnly: true,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "es2015": "dist/es2015/main.js",
   "typings": "dist/npm/main.d.ts",
   "scripts": {
-    "build-package": "gulp build-cdn && gulp build-rollup-package",
+    "build-package": "gulp build-rollup-package build-cdn",
     "test": "gulp e2e",
     "lint": "./node_modules/.bin/eslint ./src/*.js",
     "semantic-release": "semantic-release pre && semantic-prerelease publish && semantic-release post"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "typings": "dist/npm/main.d.ts",
   "scripts": {
     "build-package": "gulp build-rollup-package",
-    "test": "tsc && gulp e2e",
+    "test": "gulp e2e",
     "lint": "./node_modules/.bin/eslint ./src/*.js",
     "semantic-release": "semantic-release pre && semantic-prerelease publish && semantic-release post"
   },
@@ -21,7 +21,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/node": "10.17.13",
-    "@progress/kendo-package-tasks": "^4.0.2",
+    "@progress/kendo-package-tasks": "dev",
     "@progress/semantic-prerelease": "^3.0.0",
     "cz-conventional-changelog": "^1.1.5",
     "eslint": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/node": "10.17.13",
-    "@progress/kendo-package-tasks": "dev",
+    "@progress/kendo-package-tasks": "^4.0.39",
     "@progress/semantic-prerelease": "^3.0.0",
     "cz-conventional-changelog": "^1.1.5",
     "eslint": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@telerik/kendo-draggable",
+  "name": "@progress/kendo-draggable",
   "description": "A cross-browser/event abstraction that handles mouse and touch drag sequences",
   "author": "Progress",
   "license": "Apache-2.0",
@@ -12,7 +12,7 @@
   "scripts": {
     "build-package": "gulp build-rollup-package",
     "test": "tsc && gulp e2e",
-    "lint": "gulp lint",
+    "lint": "./node_modules/.bin/eslint ./src/*.js",
     "semantic-release": "semantic-release pre && semantic-prerelease publish && semantic-release post"
   },
   "keywords": [
@@ -22,9 +22,9 @@
   "devDependencies": {
     "@types/node": "10.17.13",
     "@progress/kendo-package-tasks": "^4.0.2",
-    "@telerik/eslint-config": "^1.0.0",
-    "@telerik/semantic-prerelease": "^1.3.3",
+    "@progress/semantic-prerelease": "^3.0.0",
     "cz-conventional-changelog": "^1.1.5",
+    "eslint": "^8.16.0",
     "ghooks": "^1.0.3",
     "gulp": "^4.0.0",
     "semantic-release": "^6.3.6",
@@ -71,11 +71,11 @@
     "fallbackTags": {
       "dev": "latest"
     },
-    "analyzeCommits": "@telerik/semantic-prerelease/analyzeCommits",
-    "generateNotes": "@telerik/semantic-prerelease/generateNotes",
-    "getLastRelease": "@telerik/semantic-prerelease/getLastRelease",
-    "verifyConditions": "@telerik/semantic-prerelease/verifyConditions",
-    "verifyRelease": "@telerik/semantic-prerelease/verifyRelease"
+    "analyzeCommits": "@progress/semantic-prerelease/analyzeCommits",
+    "generateNotes": "@progress/semantic-prerelease/generateNotes",
+    "getLastRelease": "@progress/semantic-prerelease/getLastRelease",
+    "verifyConditions": "@progress/semantic-prerelease/verifyConditions",
+    "verifyRelease": "@progress/semantic-prerelease/verifyRelease"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "description": "A cross-browser/event abstraction that handles mouse and touch drag sequences",
   "author": "Progress",
   "license": "Apache-2.0",
-  "version": "1.0.0",
+  "version": "0.0.0-semantically-released",
   "main": "dist/npm/main.js",
   "module": "dist/es/main.js",
   "jsnext:main": "dist/es/main.js",
   "es2015": "dist/es2015/main.js",
   "typings": "dist/npm/main.d.ts",
   "scripts": {
-    "build-package": "gulp build-rollup-package",
+    "build-package": "gulp build-cdn && gulp build-rollup-package",
     "test": "gulp e2e",
     "lint": "./node_modules/.bin/eslint ./src/*.js",
     "semantic-release": "semantic-release pre && semantic-prerelease publish && semantic-release post"


### PR DESCRIPTION
Cleaning up the `@telerik` scope for internal usage.

Package will be published as `@progress/kendo-draggable` v3.0.0