### PR TITLE
fix: add named export for Draggable

### DIFF
--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -5,9 +5,12 @@ interface DraggableOptions {
     mouseOnly?: boolean;
 }
 
-export default class Draggable {
+export class Draggable {
     constructor(options?: DraggableOptions);
     update(options?: DraggableOptions): void;
     bindTo(element: Element): void;
     destroy(): void;
 }
+
+export default Draggable;
+


### PR DESCRIPTION
Allows importing draggable as:
`import { Draggable } from '@progress/kendo-draggable';`

Currently it's only available as a default import in the TS definitions, but the code includes both exports.

This helps fix an issues in ESM-based projects, see https://github.com/telerik/kendo-angular/issues/3660.


